### PR TITLE
Add additional fake news sites

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -32,6 +32,8 @@ chrome.webRequest.onBeforeRequest.addListener(
       '*://*.usconservativetoday.com/*',
       '*://*.worldnewsdailyreport.com/*',
       '*://*.worldpoliticus.com/*',
+      '*://*.nationalreport.net/*',
+      '*://*.newsexaminer.net/*'
     ],
     'types': ['main_frame'],
   },


### PR DESCRIPTION
Saw this on HN and figured I'd suggest a few more:

From this [Snopes field guide to fake news](http://www.snopes.com/2016/01/14/fake-news-sites/): 

* [National Report](http://nationalreport.net/) [[Admittance of fake news](http://nationalreport.net/disclaimer/)]
* [News Examiner](http://newsexaminer.net/) [[RealOrSatire confirmation](http://realorsatire.com/newsexaminer-net/)]