### PR TITLE
list: add list by David Puente

### DIFF
--- a/src/js/urls.js
+++ b/src/js/urls.js
@@ -63,6 +63,7 @@ var urls = [
   'iltelegrafo.altervista.org',
   'imigliori.info',
   'imigliorivideo.co',
+  'incredibile.info',
   'infoquotidiano.it',
   'informazionebycuriosity.altervista.org',
   'iovivoaroma.org',

--- a/src/js/urls.js
+++ b/src/js/urls.js
@@ -116,6 +116,7 @@ var urls = [
   'repubblica24.com',
   'ridixd.altervista.org',
   'robadapazzi.com',
+  'robadapazzi.info',
   'rubrica24.altervista.org',
   'segretodistato.com',
   'shock-news.it',

--- a/src/js/urls.js
+++ b/src/js/urls.js
@@ -37,6 +37,7 @@ var urls = [
   'giornale24h.com',
   'giornaleilsole.com',
   'giornaleinformativo.altervista.org',
+  'globooggi.info',
   'grandecocomero.com',
   'grandecocomero.info',
   'guarda.link',

--- a/src/js/urls.js
+++ b/src/js/urls.js
@@ -98,6 +98,7 @@ var urls = [
   'newscronaca.it',
   'newsitalys.com',
   'noinvasione.com',
+  'noncipossocredere.info',
   'notixonline.com',
   'notixweb.com',
   'notiziariosegreto.wordpress.com',

--- a/src/js/urls.js
+++ b/src/js/urls.js
@@ -65,6 +65,7 @@ var urls = [
   'imigliorivideo.co',
   'incredibile.info',
   'infoquotidiano.it',
+  'informatiitalia.info',
   'informazionebycuriosity.altervista.org',
   'iovivoaroma.org',
   'italiahotspot.altervista.org',

--- a/src/js/urls.js
+++ b/src/js/urls.js
@@ -108,6 +108,7 @@ var urls = [
   'ohmiaitalia.com',
   'pandapazzo.com',
   'paroladiugo.it',
+  'pazzesco.info',
   'perdavvero.com',
   'piovegovernoladro.info',
   'postvirale.it',

--- a/src/js/urls.js
+++ b/src/js/urls.js
@@ -137,6 +137,7 @@ var urls = [
   'trumpvision365.com',
   'truthcdm.com',
   'tutto.tv',
+  'tutto24.info',
   'tuttoinweb.com',
   'tzetze.it',
   'ultimora24.it',

--- a/src/js/urls.js
+++ b/src/js/urls.js
@@ -42,6 +42,7 @@ var urls = [
   'guarda.link',
   'guarda.one',
   'guardache.info',
+  'guardache.news',
   'hotglobalnews.com',
   'ilbellocheavanza.com',
   'ilcorriere.cloud',

--- a/src/js/urls.js
+++ b/src/js/urls.js
@@ -54,6 +54,7 @@ var urls = [
   'ilgiornalenews.com',
   'ilmattoquotidiano.it',
   'ilmessaggio.it',
+  'ilmondoit.info',
   'ilpatriota.it',
   'ilpinguinoinnamorato.it',
   'ilquotidaino.wordpress.com',

--- a/src/js/urls.js
+++ b/src/js/urls.js
@@ -41,6 +41,7 @@ var urls = [
   'grandecocomero.info',
   'guarda.link',
   'guarda.one',
+  'guardache.info',
   'hotglobalnews.com',
   'ilbellocheavanza.com',
   'ilcorriere.cloud',


### PR DESCRIPTION
From here: https://www.davidpuente.it/blog/2017/10/04/una-rete-organizzata-di-siti-albanesi-avvelenano-il-web-italiano/